### PR TITLE
chore: set ld library path in the build.rs on debug mode

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -33,8 +33,6 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
-      - name: Set LD_LIBRARY_PATH
-        run: echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$JAVA_HOME/jre/lib/amd64/server" >> $GITHUB_ENV
       - name: Build
         run: cargo build --verbose
       - name: Run tests

--- a/build.rs
+++ b/build.rs
@@ -1,11 +1,47 @@
+use std::env;
+use std::path::Path;
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // let config = tonic_build::configure();
-    // config
-    //     .build_server(true)
-    //     .out_dir("src/proto")
-    //     .compile(
-    //         &["src/proto/uniffle.proto"],
-    //         &["src/proto"],
-    //     )?;
+    // todo: use [protobuf-codegen](https://crates.io/crates/protobuf-codegen) to generate rust code
+
+    // only setup ld library path in debug mode
+    let profile = std::env::var("PROFILE").unwrap();
+    if profile == "debug" {
+        setup_ld_library_path();
+    }
     Ok(())
+}
+
+fn setup_ld_library_path() {
+    // java_home is required now to build and test
+    let java_home = env::var("JAVA_HOME").expect("JAVA_HOME must be set");
+    let possible_lib_paths = vec![
+        format!("{java_home}/jre/lib/amd64/server/"),
+        format!("{java_home}/lib/server"),
+        format!("{java_home}/jre/lib/server"),
+        format!("{java_home}/jre/lib/amd64/server")
+    ];
+    let lib_jvm_path = possible_lib_paths.iter().find(|&path| {
+        let path = Path::new(&path);
+        path.exists()
+    }).expect("java_home is not valid");
+    match env::consts::OS {
+        "linux" => {
+            let ld_path = env::var_os("LD_LIBRARY_PATH").unwrap_or("".parse().unwrap());
+            let ld_path = format!("{}:{}",
+                                  ld_path.to_str().unwrap(), lib_jvm_path);
+            // this might be anti-pattern, but it works for our current setup
+            println!("cargo:rustc-env=LD_LIBRARY_PATH={}", ld_path);
+        }
+        "macos" => {
+            let ld_path = env::var_os("DYLD_LIBRARY_PATH").unwrap_or("".parse().unwrap());
+            let ld_path = format!("{}:{}",
+                                  ld_path.to_str().unwrap(), lib_jvm_path);
+            // this might be anti-pattern, but it works for our current setup
+            println!("cargo:rustc-env=DYLD_LIBRARY_PATH={}", ld_path);
+        }
+        _ => {
+            // do nothing
+        }
+    }
 }


### PR DESCRIPTION
This commit enables that we can simply call cargo test/run to invoke tests or runs without set LD_LIBRARY_PATH or similar manually. It helps a lot that test/run configurations generated on IDEA/Clion with rust plugin could be launched without more manual configurations.

This works for linux and macos