### PR TITLE
feat(hdfs): introduce concurrency limiter for per hdfs cluster

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,7 @@ pub struct MemoryStoreConfig {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct HdfsStoreConfig {
     pub data_path: String,
+    pub max_concurrency: Option<i32>
 }
 
 // =========================================================


### PR DESCRIPTION
I'm not sure why the hdrs client only supports one concurrency of writing.
Anyway, let's add the concurrency limiter for writing firstly.