### PR TITLE
improvement(hybrid): limit memory spill max concurrency to avoid too …

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -46,7 +46,9 @@ pub struct HybridStoreConfig {
     pub memory_spill_high_watermark: f32,
     pub memory_spill_low_watermark: f32,
     pub memory_single_buffer_max_spill_size: Option<String>,
-    pub memory_spill_to_cold_threshold_size: Option<String>
+    pub memory_spill_to_cold_threshold_size: Option<String>,
+
+    pub memory_spill_max_concurrency: Option<i32>,
 }
 
 impl HybridStoreConfig {
@@ -55,7 +57,8 @@ impl HybridStoreConfig {
             memory_spill_high_watermark,
             memory_spill_low_watermark,
             memory_single_buffer_max_spill_size,
-            memory_spill_to_cold_threshold_size: None
+            memory_spill_to_cold_threshold_size: None,
+            memory_spill_max_concurrency: None,
         }
     }
 }
@@ -66,7 +69,8 @@ impl Default for HybridStoreConfig {
             memory_spill_high_watermark: 0.8,
             memory_spill_low_watermark: 0.7,
             memory_single_buffer_max_spill_size: None,
-            memory_spill_to_cold_threshold_size: None
+            memory_spill_to_cold_threshold_size: None,
+            memory_spill_max_concurrency: None,
         }
     }
 }


### PR DESCRIPTION
…much task await for tokio scheudler

Background:

This PR is to introduce the max concurrency for acquiring spill operation from queue, which is to avoid causing too much await tasks for tokio scheduler. After testing, too much tasks will make tokio hang.

Anyway, the max_concurrency for localfile/hdfs writing is necessary to avoid too high io wait.