### PR TITLE
feat: throw concrete error in store trait

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -151,7 +151,7 @@ impl App {
         Ok(())
     }
 
-    pub async fn insert(&self, ctx: WritingViewContext) -> Result<()> {
+    pub async fn insert(&self, ctx: WritingViewContext) -> Result<(), DatanodeError> {
         let len: i32 = ctx.data_blocks.iter().map(|block| block.length).sum();
         self.get_underlying_partition_bitmap(ctx.uid.clone()).incr_data_size(len);
         TOTAL_RECEIVED_DATA.inc_by(len as u64);
@@ -159,11 +159,11 @@ impl App {
         self.store.insert(ctx).await
     }
 
-    pub async fn select(&self, ctx: ReadingViewContext) -> Result<ResponseData> {
+    pub async fn select(&self, ctx: ReadingViewContext) -> Result<ResponseData, DatanodeError> {
         self.store.get(ctx).await
     }
 
-    pub async fn list_index(&self, ctx: ReadingIndexViewContext) -> Result<ResponseDataIndex> {
+    pub async fn list_index(&self, ctx: ReadingIndexViewContext) -> Result<ResponseDataIndex, DatanodeError> {
         self.store.get_index(ctx).await
     }
 

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -14,6 +14,7 @@ use crate::store::{DataSegment, PartitionedDataBlock, PartitionedMemoryData, Res
 use async_trait::async_trait;
 use tokio::sync::Mutex;
 use crate::config::MemoryStoreConfig;
+use crate::error::DatanodeError;
 use crate::metric::{GAUGE_MEMORY_ALLOCATED, GAUGE_MEMORY_CAPACITY, GAUGE_MEMORY_USED, TOTAL_MEMORY_USED};
 use crate::readable_size::ReadableSize;
 
@@ -166,7 +167,7 @@ impl Store for MemoryStore {
         todo!()
     }
 
-    async fn insert(&self, ctx: WritingViewContext) -> Result<()> {
+    async fn insert(&self, ctx: WritingViewContext) -> Result<(), DatanodeError> {
         let uid = ctx.uid;
         let buffer = self.get_or_create_underlying_staging_buffer(uid.clone());
         let mut buffer_guarded = buffer.lock().await;
@@ -180,7 +181,7 @@ impl Store for MemoryStore {
         Ok(())
     }
 
-    async fn get(&self, ctx: ReadingViewContext) -> Result<ResponseData> {
+    async fn get(&self, ctx: ReadingViewContext) -> Result<ResponseData, DatanodeError> {
         let uid = ctx.uid;
         let buffer = self.get_or_create_underlying_staging_buffer(uid);
         let mut buffer = buffer.lock().await;
@@ -288,7 +289,7 @@ impl Store for MemoryStore {
         ))
     }
 
-    async fn get_index(&self, ctx: ReadingIndexViewContext) -> Result<ResponseDataIndex> {
+    async fn get_index(&self, ctx: ReadingIndexViewContext) -> Result<ResponseDataIndex, DatanodeError> {
         panic!("It should not be invoked.")
     }
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -28,6 +28,7 @@ use crate::proto::uniffle::{ShuffleBlock, ShuffleData, ShuffleDataBlockSegment};
 use crate::store::ResponseDataIndex::local;
 use async_trait::async_trait;
 use crate::config::Config;
+use crate::error::DatanodeError;
 use crate::store::hybrid::HybridStore;
 use crate::store::memory::MemoryStore;
 
@@ -137,9 +138,9 @@ impl Into<ShuffleDataBlockSegment> for DataSegment {
 #[async_trait]
 pub trait Store {
     fn start(self: Arc<Self>);
-    async fn insert(&self, ctx: WritingViewContext) -> Result<()>;
-    async fn get(&self, ctx: ReadingViewContext) -> Result<ResponseData>;
-    async fn get_index(&self, ctx: ReadingIndexViewContext) -> Result<ResponseDataIndex>;
+    async fn insert(&self, ctx: WritingViewContext) -> Result<(), DatanodeError>;
+    async fn get(&self, ctx: ReadingViewContext) -> Result<ResponseData, DatanodeError>;
+    async fn get_index(&self, ctx: ReadingIndexViewContext) -> Result<ResponseDataIndex, DatanodeError>;
     async fn require_buffer(&self, ctx: RequireBufferContext) -> Result<(bool, i64)>;
     async fn purge(&self, app_id: String) -> Result<()>;
     async fn is_healthy(&self) -> Result<bool>;


### PR DESCRIPTION
We will use the concrete error to decide which storage to re-insert when the first inserting fails.
This PR is the first step to finish above.