### PR TITLE
[#10][part-0]feat(profile): support cpu profiling online 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,33 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16,6 +43,12 @@ name = "anyhow"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "async-channel"
@@ -129,6 +162,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,6 +223,12 @@ name = "bumpalo"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+
+[[package]]
+name = "bytemuck"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
 
 [[package]]
 name = "byteorder"
@@ -236,6 +290,15 @@ name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+
+[[package]]
+name = "cpp_demangle"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee34052ee3d93d6d8f3e6f81d85c47921f6653a19a7b70e939e3e602d893a674"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -400,6 +463,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,6 +574,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -689,6 +773,12 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "h2"
@@ -912,6 +1002,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c40411d0e5c63ef1323c3d09ce5ec6d84d71531e18daed0743fccea279d7deb6"
 
 [[package]]
+name = "inferno"
+version = "0.11.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fb7c1b80a1dfa604bb4a649a5c5aeef3d913f7c520cb42b40e534e8a61bcdfc"
+dependencies = [
+ "ahash",
+ "indexmap",
+ "is-terminal",
+ "itoa",
+ "log",
+ "num-format",
+ "once_cell",
+ "quick-xml",
+ "rgb",
+ "str_stack",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,6 +1146,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memmap2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1060,6 +1177,15 @@ checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
 dependencies = [
  "mime",
  "unicase",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
 ]
 
 [[package]]
@@ -1117,6 +1243,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+ "static_assertions",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1127,6 +1265,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "itoa",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1134,6 +1282,15 @@ checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
  "hermit-abi 0.2.6",
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.30.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1276,6 +1433,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
+name = "pprof"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "196ded5d4be535690899a4631cc9f18cdc41b7ebf24a79400f46f48e49a11059"
+dependencies = [
+ "backtrace",
+ "cfg-if",
+ "findshlibs",
+ "inferno",
+ "libc",
+ "log",
+ "nix",
+ "once_cell",
+ "parking_lot",
+ "protobuf",
+ "protobuf-codegen-pure",
+ "smallvec",
+ "symbolic-demangle",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1390,6 +1570,34 @@ name = "protobuf"
 version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
+name = "protobuf-codegen"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "033460afb75cf755fcfc16dfaed20b86468082a2ea24e05ac35ab4a099a017d6"
+dependencies = [
+ "protobuf",
+]
+
+[[package]]
+name = "protobuf-codegen-pure"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a29399fc94bcd3eeaa951c715f7bea69409b2445356b00519740bcd6ddd865"
+dependencies = [
+ "protobuf",
+ "protobuf-codegen",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quote"
@@ -1558,6 +1766,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rgb"
+version = "0.8.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20ec2d3e3fc7a92ced357df9cebd5a10b6fb2aa1ee797bf7e9ce2f17dffc8f59"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,6 +1788,12 @@ dependencies = [
  "web-sys",
  "winapi",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
@@ -1807,16 +2030,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "str_stack"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "symbolic-common"
+version = "10.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b55cdc318ede251d0957f07afe5fed912119b8c1bc5a7804151826db999e737"
+dependencies = [
+ "debugid",
+ "memmap2",
+ "stable_deref_trait",
+ "uuid",
+]
+
+[[package]]
+name = "symbolic-demangle"
+version = "10.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79be897be8a483a81fff6a3a4e195b4ac838ef73ca42d348b3f722da9902e489"
+dependencies = [
+ "cpp_demangle",
+ "rustc-demangle",
+ "symbolic-common",
+]
 
 [[package]]
 name = "syn"
@@ -2326,6 +2584,7 @@ dependencies = [
  "hdrs",
  "lazy_static",
  "log",
+ "pprof",
  "prometheus",
  "prost",
  "serde",
@@ -2367,6 +2626,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "uuid"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,19 @@ url = "2.4.0"
 await-tree = "0.1.1"
 hdrs = { version = "0.3.0", features = ["async_file"] }
 
+pprof = { version = "0.11.1", features = [
+    "flamegraph",
+    "protobuf-codec",
+    "protobuf",
+] }
+
 [build-dependencies]
 tonic-build = "0.9.1"
 
 [dev-dependencies]
 env_logger = "0.10.0"
+
+[profile.dev]
+# re-enable debug assertions when pprof-rs fixed the reports for misaligned pointer dereferences
+#   https://github.com/rust-lang/rust/pull/98112/
+debug-assertions = false

--- a/src/http/http_service.rs
+++ b/src/http/http_service.rs
@@ -1,0 +1,52 @@
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use warp::Filter;
+use log::info;
+
+use crate::http::metrics::metrics_handler;
+use crate::http::pprof::{PProfRequest, pprof_handler};
+
+pub trait HTTPServer: Send {
+    fn start(&mut self);
+}
+
+pub fn new_server(port: u16) -> impl HTTPServer {
+    WarpServer::new(port)
+}
+
+struct WarpServer {
+    port: u16,
+}
+
+impl WarpServer {
+    fn new(port: u16) -> Self {
+        WarpServer {
+            port,
+        }
+    }
+}
+
+impl HTTPServer for WarpServer {
+    fn start(&mut self) {
+        let hello_world = warp::path::end().map(|| "Hello uniffle server");
+
+        // todo: maybe we should replace warp with other rest framework, it's super weired to
+        //   support conditional routing.
+        let metrics_route = warp::get()
+            .and(warp::path("metrics"))
+            .and_then(metrics_handler);
+
+        let pprof_route = warp::get()
+            .and(warp::path!("debug" / "pprof" / "profile"))
+            .and(warp::query::<PProfRequest>())
+            .and_then(pprof_handler);
+
+        let routes = hello_world.or(metrics_route).or(pprof_route);
+        let port = self.port;
+        info!("Starting http service with port:[{}] ......", port);
+        tokio::spawn(async move {
+            warp::serve(routes)
+                .run(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), port))
+                .await;
+        });
+    }
+}

--- a/src/http/metrics.rs
+++ b/src/http/metrics.rs
@@ -1,0 +1,38 @@
+use log::error;
+use warp::{Rejection, Reply};
+
+use crate::metric::REGISTRY;
+
+pub async fn metrics_handler() -> Result<impl Reply, Rejection> {
+    use prometheus::Encoder;
+    let encoder = prometheus::TextEncoder::new();
+
+    let mut buffer = Vec::new();
+    if let Err(e) = encoder.encode(&REGISTRY.gather(), &mut buffer) {
+        error!("could not encode custom metrics: {:?}", e);
+    };
+    let mut res = match String::from_utf8(buffer.clone()) {
+        Ok(v) => v,
+        Err(e) => {
+            error!("custom metrics could not be from_utf8'd: {:?}", e);
+            String::default()
+        }
+    };
+    buffer.clear();
+
+    let mut buffer = Vec::new();
+    if let Err(e) = encoder.encode(&prometheus::gather(), &mut buffer) {
+        error!("could not encode prometheus metrics: {:?}", e);
+    };
+    let res_custom = match String::from_utf8(buffer.clone()) {
+        Ok(v) => v,
+        Err(e) => {
+            error!("prometheus metrics could not be from_utf8'd: {}", e);
+            String::default()
+        }
+    };
+    buffer.clear();
+
+    res.push_str(&res_custom);
+    Ok(res)
+}

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1,0 +1,3 @@
+pub mod metrics;
+pub mod pprof;
+pub mod http_service;

--- a/src/http/pprof.rs
+++ b/src/http/pprof.rs
@@ -1,0 +1,48 @@
+use log::error;
+use std::num::NonZeroI32;
+use std::time::Duration;
+use serde::{Deserialize,Serialize};
+use tokio::time::sleep as delay_for;
+use pprof::ProfilerGuard;
+use pprof::protos::Message;
+use warp::{Rejection, Reply};
+
+#[derive(Deserialize, Serialize)]
+#[serde(default)]
+pub struct PProfRequest {
+    pub(crate) seconds: u64,
+    pub(crate) frequency: NonZeroI32,
+}
+
+impl Default for PProfRequest {
+    fn default() -> Self {
+        PProfRequest {
+            seconds: 5,
+            frequency: NonZeroI32::new(100).unwrap(),
+        }
+    }
+}
+
+pub async fn pprof_handler(req: PProfRequest) -> Result<impl Reply, Rejection> {
+    let mut body: Vec<u8> = Vec::new();
+
+    let guard = ProfilerGuard::new(req.frequency.into()).map_err(|e| {
+        error!("could not start profiling: {:?}", e);
+        warp::reject::reject()
+    })?;
+    delay_for(Duration::from_secs(req.seconds)).await;
+    let report = guard.report().build().map_err(|e| {
+        error!("could not build profiling report: {:?}", e);
+        warp::reject::reject()
+    })?;
+    let profile = report.pprof()
+        .map_err(|e| {
+            error!("could not get pprof profile: {:?}", e);
+            warp::reject::reject()
+        })?;
+    profile.write_to_vec(&mut body).map_err(|e| {
+        error!("could not write pprof profile: {:?}", e);
+        warp::reject::reject()
+    })?;
+    Ok(body)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,17 +8,29 @@ pub mod metric;
 pub mod util;
 pub mod readable_size;
 pub mod await_tree;
+mod http;
 
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use anyhow::Result;
 use log::info;
-use tokio::runtime::Runtime;
 use tonic::transport::Server;
 use crate::app::AppManager;
+use crate::util::gen_datanode_uid;
 use crate::grpc::DefaultShuffleServer;
+use crate::http::http_service::HTTPServer;
+use crate::http::http_service::new_server;
+use crate::metric::configure_metric_service;
 use crate::proto::uniffle::shuffle_server_server::ShuffleServerServer;
 
 pub async fn start_datanode(config: config::Config) -> Result<()> {
+    let rpc_port = config.grpc_port.unwrap_or(19999);
+    let datanode_uid = gen_datanode_uid(rpc_port);
+    let metric_config = config.metrics.clone();
+    let start_http_service = configure_metric_service(&metric_config, datanode_uid.clone());
+    if start_http_service {
+        let mut server = new_server(metric_config.unwrap().http_port.unwrap_or(19998) as u16);
+        server.start();
+    }
     // implement server startup
     tokio::spawn(async move {
         let app_manager_ref = AppManager::get_ref(config.clone());

--- a/src/util.rs
+++ b/src/util.rs
@@ -20,6 +20,11 @@ pub fn get_local_ip() -> Result<IpAddr, std::io::Error> {
     }
 }
 
+pub fn gen_datanode_uid(grpc_port: i32) -> String {
+    let ip = get_local_ip().unwrap().to_string();
+    format!("{}-{}", ip.clone(), grpc_port)
+}
+
 const LENGTH_PER_CRC: usize = 4 * 1024;
 pub fn get_crc(bytes: &Bytes) -> i64 {
     let mut crc32 = Hasher::new();


### PR DESCRIPTION
After start uniffle server, it should be possible to get cpu pprof via 
```
go tool pprof -http="0.0.0.0:8081" http://localhost:8080/debug/pprof/profile\?seconds\=30\&frequency\=100
```
Note: `localhost:8080` is uniffle's http server.

One profiling result:
<img width="1847" alt="image" src="https://github.com/zuston/uniffle-x/assets/807537/f0f87f30-62d1-4b28-90cd-6efe4cdb74fd">

