### PR TITLE
chore: treat all warnings as errors except one rule: dead-code

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-A", "dead-code", "-D", "warnings"]

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /target
 .DS_Store
 .idea
-config.toml
 src/proto/uniffle.rs

--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ memory_spill_low_watermark = 0.4
 
 `cargo build --release`
 
+Uniffle-x currently treats all compiler warnings as error, with some dead-code warning excluded. When you are developing
+and really want to ignore the warnings for now, you can use `ccargo --config 'build.rustflags=["-W", "warnings"]' build`
+to restore the default behavior. However, before submit your pr, you should fix all the warnings.
+
 
 ## Config
 

--- a/src/await_tree.rs
+++ b/src/await_tree.rs
@@ -1,8 +1,8 @@
 use await_tree::Registry;
 use lazy_static::lazy_static;
-use log::info;
+
 use std::sync::Arc;
-use std::time::Duration;
+
 use tokio::sync::Mutex;
 
 lazy_static! {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,3 @@
-use crate::store::hybrid::HybridStore;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;
@@ -138,6 +137,7 @@ pub enum RotationConfig {
 // =========================================================
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Copy)]
+#[allow(non_camel_case_types)]
 pub enum StorageType {
     MEMORY = 1,
     LOCALFILE = 2,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,14 +1,13 @@
-use crate::app::PurgeEvent;
 use crate::error::DatanodeError::Other;
 use anyhow::Error;
-use crossbeam_channel::SendError;
+
 use log::error;
 use poem::error::ParseQueryError;
-use std::fmt::{Display, Formatter, Write};
 use thiserror::Error;
 use tokio::sync::AcquireError;
 
 #[derive(Error, Debug)]
+#[allow(non_camel_case_types)]
 pub enum DatanodeError {
     #[error("There is no available disks in local file store")]
     NO_AVAILABLE_LOCAL_DISK,
@@ -49,8 +48,8 @@ impl From<ParseQueryError> for DatanodeError {
 
 #[cfg(test)]
 mod tests {
-    use crate::error::DatanodeError;
-    use anyhow::{anyhow, bail, Result};
+
+    use anyhow::Result;
 
     #[test]
     pub fn error_test() -> Result<()> {

--- a/src/http/await_tree.rs
+++ b/src/http/await_tree.rs
@@ -2,7 +2,6 @@ use crate::await_tree::AWAIT_TREE_REGISTRY;
 use crate::http::Handler;
 use poem::endpoint::make;
 use poem::{get, RouteMethod};
-use tokio::sync::Mutex;
 
 pub struct AwaitTreeHandler {}
 

--- a/src/http/http_service.rs
+++ b/src/http/http_service.rs
@@ -1,12 +1,11 @@
 use crate::error::DatanodeError;
-use anyhow::Result;
-use log::info;
+
 use poem::endpoint::make_sync;
 use poem::error::ResponseError;
 use poem::http::StatusCode;
 use poem::listener::TcpListener;
 use poem::{get, Route, RouteMethod, Server};
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
 use std::sync::Mutex;
 
 use crate::http::{HTTPServer, Handler};

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -9,7 +9,6 @@ use crate::http::metrics::MetricsHTTPHandler;
 use crate::http::pprof::PProfHandler;
 use lazy_static::lazy_static;
 use poem::RouteMethod;
-use std::sync::{Arc, Mutex};
 
 lazy_static! {
     pub static ref HTTP_SERVICE: Box<PoemHTTPServer> = new_server();

--- a/src/http/pprof.rs
+++ b/src/http/pprof.rs
@@ -1,15 +1,14 @@
 use crate::error::DatanodeError;
 use crate::http::Handler;
 use log::error;
-use poem::endpoint::{make, make_sync};
-use poem::{get, handler, Request, RouteMethod};
+
+use poem::{handler, Request, RouteMethod};
 use pprof::protos::Message;
 use pprof::ProfilerGuard;
 use serde::{Deserialize, Serialize};
 use std::num::NonZeroI32;
 use std::time::Duration;
 use tokio::time::sleep as delay_for;
-use tracing_subscriber::fmt::format;
 
 #[derive(Deserialize, Serialize)]
 #[serde(default)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,9 +10,8 @@ use crate::proto::uniffle::shuffle_server_server::ShuffleServerServer;
 use crate::proto::uniffle::{ShuffleServerHeartBeatRequest, ShuffleServerId};
 use crate::util::{gen_datanode_uid, get_local_ip};
 use anyhow::Result;
-use futures::StreamExt;
 use log::info;
-use std::borrow::BorrowMut;
+
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::time::Duration;
 use tonic::transport::{Channel, Server};
@@ -183,12 +182,6 @@ async fn main() -> Result<()> {
 #[cfg(test)]
 mod test {
     use crate::get_local_ip;
-    use crate::proto::uniffle::shuffle_server_client::ShuffleServerClient;
-    use anyhow::Result;
-    use std::borrow::BorrowMut;
-    use std::cell::RefCell;
-    use std::rc::Rc;
-    use tokio_stream::StreamExt;
 
     #[test]
     fn get_local_ip_test() {

--- a/src/metric.rs
+++ b/src/metric.rs
@@ -143,7 +143,7 @@ pub fn configure_metric_service(
 
     let push_gateway_endpoint = cfg.push_gateway_endpoint;
 
-    if let Some(ref endpoint) = push_gateway_endpoint {
+    if let Some(ref _endpoint) = push_gateway_endpoint {
         let push_interval_sec = cfg.push_interval_sec.unwrap_or(60);
         tokio::spawn(async move {
             info!("Starting prometheus metrics exporter...");

--- a/src/store/hdfs.rs
+++ b/src/store/hdfs.rs
@@ -4,31 +4,29 @@ use crate::app::{
 };
 use crate::config::HdfsStoreConfig;
 use crate::error::DatanodeError;
-use crate::error::DatanodeError::Other;
-use crate::metric::{TOTAL_HDFS_USED, TOTAL_MEMORY_SPILL_TO_HDFS};
+
+use crate::metric::TOTAL_HDFS_USED;
 use crate::store::{Persistent, RequireBufferResponse, ResponseData, ResponseDataIndex, Store};
-use anyhow::{anyhow, Error, Result};
-use async_channel::Sender;
+use anyhow::Result;
+
 use async_trait::async_trait;
 use await_tree::InstrumentAwait;
 use bytes::{BufMut, Bytes, BytesMut};
 use dashmap::DashMap;
-use futures::future::select;
+
 use futures::AsyncWriteExt;
 use hdrs::{Client, ClientBuilder};
 use log::{error, info};
-use std::collections::HashMap;
-use std::hash::Hash;
+
 use std::path::Path;
-use std::sync::atomic::AtomicI64;
+
 use std::sync::Arc;
 use std::{env, io};
-use tokio::sync::{AcquireError, Mutex, Semaphore};
-use toml::map::Entry;
+use tokio::sync::{Mutex, Semaphore};
+
 use tracing::debug;
-use tracing_subscriber::registry::Data;
-use url::form_urlencoded::parse;
-use url::{ParseError, Url};
+
+use url::Url;
 
 struct PartitionCachedMeta {
     is_file_created: bool,
@@ -140,7 +138,7 @@ impl Store for HdfsStore {
             .entry(data_file_path.clone())
             .or_insert_with(|| Arc::new(Mutex::new(())))
             .clone();
-        let lock_guard = lock_cloned
+        let _lock_guard = lock_cloned
             .lock()
             .instrument_await(format!(
                 "hdfs partition file lock. path: {}",
@@ -213,20 +211,20 @@ impl Store for HdfsStore {
         Ok(())
     }
 
-    async fn get(&self, ctx: ReadingViewContext) -> Result<ResponseData, DatanodeError> {
+    async fn get(&self, _ctx: ReadingViewContext) -> Result<ResponseData, DatanodeError> {
         todo!()
     }
 
     async fn get_index(
         &self,
-        ctx: ReadingIndexViewContext,
+        _ctx: ReadingIndexViewContext,
     ) -> Result<ResponseDataIndex, DatanodeError> {
         todo!()
     }
 
     async fn require_buffer(
         &self,
-        ctx: RequireBufferContext,
+        _ctx: RequireBufferContext,
     ) -> Result<RequireBufferResponse, DatanodeError> {
         todo!()
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,11 +1,8 @@
 use bytes::Bytes;
 use crc32fast::Hasher;
-use std::cell::RefCell;
-use std::cmp::max;
-use std::collections::hash_map::DefaultHasher;
-use std::hash::Hash;
+
 use std::net::IpAddr;
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 pub fn get_local_ip() -> Result<IpAddr, std::io::Error> {
@@ -85,9 +82,8 @@ impl Drop for Ticket<'_> {
 
 #[cfg(test)]
 mod test {
-    use crate::util::{current_timestamp_sec, get_crc, ConcurrencyLimiter, Ticket};
+    use crate::util::{current_timestamp_sec, get_crc, ConcurrencyLimiter};
     use bytes::Bytes;
-    use std::sync::Arc;
 
     #[test]
     fn ticket_test() {

--- a/tests/write_read.rs
+++ b/tests/write_read.rs
@@ -8,13 +8,11 @@ mod tests {
     };
     use datanode::proto::uniffle::shuffle_server_client::ShuffleServerClient;
     use datanode::proto::uniffle::{
-        DataDistribution, GetLocalShuffleDataRequest, GetLocalShuffleIndexRequest,
-        GetMemoryShuffleDataRequest, PartitionToBlockIds, ReportShuffleResultRequest,
+        GetLocalShuffleDataRequest, GetLocalShuffleIndexRequest, GetMemoryShuffleDataRequest,
         SendShuffleDataRequest, ShuffleBlock, ShuffleData, ShuffleRegisterRequest,
     };
     use datanode::start_datanode;
-    use datanode::util::get_crc;
-    use std::thread;
+
     use std::time::Duration;
     use tonic::transport::Channel;
 
@@ -47,10 +45,10 @@ mod tests {
     }
 
     async fn get_data_from_remote(
-        client: &ShuffleServerClient<Channel>,
-        app_id: &str,
-        shuffle_id: i32,
-        partitions: Vec<i32>,
+        _client: &ShuffleServerClient<Channel>,
+        _app_id: &str,
+        _shuffle_id: i32,
+        _partitions: Vec<i32>,
     ) {
     }
 


### PR DESCRIPTION
This commit try to fix various code/lint issues: unused import, non snake_case variables, unmatched pattern arms etc. After the fix, we can enable treating all warnings as errors.

The purpose of this commit is to reduce the warning logs when building, which is annoying to find the real errors/problems.