### PR TITLE
improvement: replace async lock to std mutex in await-tree registry

### DIFF
--- a/src/await_tree.rs
+++ b/src/await_tree.rs
@@ -19,9 +19,7 @@ use await_tree::{Registry, TreeRoot};
 
 use once_cell::sync::Lazy;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
-
-use tokio::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 type AwaitTreeRegistryRef = Arc<Mutex<Registry<u64>>>;
 
@@ -44,7 +42,7 @@ impl AwaitTreeInner {
     pub async fn register(&self, msg: String) -> TreeRoot {
         let id = self.next_id.fetch_add(1, Ordering::SeqCst);
         let msg = format!("actor=[{}], {}", id, msg);
-        self.inner.lock().await.register(id, msg)
+        self.inner.lock().unwrap().register(id, msg)
     }
 
     pub fn get_inner(&self) -> AwaitTreeRegistryRef {

--- a/src/http/await_tree.rs
+++ b/src/http/await_tree.rs
@@ -32,7 +32,7 @@ impl Handler for AwaitTreeHandler {
     fn get_route_method(&self) -> RouteMethod {
         get(make(|_| async {
             let registry_cloned = AWAIT_TREE_REGISTRY.clone().get_inner();
-            let registry = registry_cloned.lock().await;
+            let registry = registry_cloned.lock().unwrap();
             let mut dynamic_string = String::new();
             for (_, tree) in registry.iter() {
                 let raw_tree = format!("{}", tree);


### PR DESCRIPTION
After applied this optimization, the terasort (400 executor. 5TB) costs 4.3min(write)/6.5min(read) . It looks good compared with the original benchmark (7.6/6.2)