### PR TITLE
fix: incorrect transport time in critical grpc requests

### DIFF
--- a/src/grpc.rs
+++ b/src/grpc.rs
@@ -115,14 +115,14 @@ impl ShuffleServer for DefaultShuffleServer {
         &self,
         request: Request<SendShuffleDataRequest>,
     ) -> Result<Response<SendShuffleDataResponse>, Status> {
+        GRPC_SEND_DATA_TRANSPORT_TIME
+            .observe((util::current_timestamp_ms() - req.timestamp as u128) as f64);
+
         let timer = GRPC_SEND_DATA_PROCESS_TIME.start_timer();
         let req = request.into_inner();
         let app_id = req.app_id;
         let shuffle_id: i32 = req.shuffle_id;
         let ticket_id = req.require_buffer_id;
-
-        GRPC_SEND_DATA_TRANSPORT_TIME
-            .observe((util::current_timestamp_sec() - req.timestamp as u64) as f64);
 
         let app_option = self.app_manager_ref.get_app(&app_id);
 
@@ -256,14 +256,14 @@ impl ShuffleServer for DefaultShuffleServer {
         &self,
         request: Request<GetLocalShuffleDataRequest>,
     ) -> Result<Response<GetLocalShuffleDataResponse>, Status> {
+        GRPC_GET_MEMORY_DATA_TRANSPORT_TIME
+            .observe((util::current_timestamp_ms() - req.timestamp as u128) as f64);
+        
         let timer = GRPC_GET_LOCALFILE_DATA_PROCESS_TIME.start_timer();
         let req = request.into_inner();
         let app_id = req.app_id;
         let shuffle_id: i32 = req.shuffle_id;
         let partition_id = req.partition_id;
-
-        GRPC_GET_MEMORY_DATA_TRANSPORT_TIME
-            .observe((util::current_timestamp_sec() - req.timestamp as u64) as f64);
 
         let app = self.app_manager_ref.get_app(&app_id);
         if app.is_none() {
@@ -317,14 +317,14 @@ impl ShuffleServer for DefaultShuffleServer {
         &self,
         request: Request<GetMemoryShuffleDataRequest>,
     ) -> Result<Response<GetMemoryShuffleDataResponse>, Status> {
+        GRPC_GET_MEMORY_DATA_TRANSPORT_TIME
+            .observe((util::current_timestamp_ms() - req.timestamp as u128) as f64);
+
         let timer = GRPC_GET_MEMORY_DATA_PROCESS_TIME.start_timer();
         let req = request.into_inner();
         let app_id = req.app_id;
         let shuffle_id: i32 = req.shuffle_id;
         let partition_id = req.partition_id;
-
-        GRPC_GET_MEMORY_DATA_TRANSPORT_TIME
-            .observe((util::current_timestamp_sec() - req.timestamp as u64) as f64);
 
         let app = self.app_manager_ref.get_app(&app_id);
         if app.is_none() {

--- a/src/grpc.rs
+++ b/src/grpc.rs
@@ -115,14 +115,14 @@ impl ShuffleServer for DefaultShuffleServer {
         &self,
         request: Request<SendShuffleDataRequest>,
     ) -> Result<Response<SendShuffleDataResponse>, Status> {
-        GRPC_SEND_DATA_TRANSPORT_TIME
-            .observe((util::current_timestamp_ms() - req.timestamp as u128) as f64);
-
         let timer = GRPC_SEND_DATA_PROCESS_TIME.start_timer();
         let req = request.into_inner();
         let app_id = req.app_id;
         let shuffle_id: i32 = req.shuffle_id;
         let ticket_id = req.require_buffer_id;
+
+        GRPC_SEND_DATA_TRANSPORT_TIME
+            .observe((util::current_timestamp_ms() - req.timestamp as u128) as f64);
 
         let app_option = self.app_manager_ref.get_app(&app_id);
 
@@ -256,14 +256,14 @@ impl ShuffleServer for DefaultShuffleServer {
         &self,
         request: Request<GetLocalShuffleDataRequest>,
     ) -> Result<Response<GetLocalShuffleDataResponse>, Status> {
-        GRPC_GET_MEMORY_DATA_TRANSPORT_TIME
-            .observe((util::current_timestamp_ms() - req.timestamp as u128) as f64);
-        
         let timer = GRPC_GET_LOCALFILE_DATA_PROCESS_TIME.start_timer();
         let req = request.into_inner();
         let app_id = req.app_id;
         let shuffle_id: i32 = req.shuffle_id;
         let partition_id = req.partition_id;
+
+        GRPC_GET_MEMORY_DATA_TRANSPORT_TIME
+            .observe((util::current_timestamp_ms() - req.timestamp as u128) as f64);
 
         let app = self.app_manager_ref.get_app(&app_id);
         if app.is_none() {
@@ -317,14 +317,14 @@ impl ShuffleServer for DefaultShuffleServer {
         &self,
         request: Request<GetMemoryShuffleDataRequest>,
     ) -> Result<Response<GetMemoryShuffleDataResponse>, Status> {
-        GRPC_GET_MEMORY_DATA_TRANSPORT_TIME
-            .observe((util::current_timestamp_ms() - req.timestamp as u128) as f64);
-
         let timer = GRPC_GET_MEMORY_DATA_PROCESS_TIME.start_timer();
         let req = request.into_inner();
         let app_id = req.app_id;
         let shuffle_id: i32 = req.shuffle_id;
         let partition_id = req.partition_id;
+
+        GRPC_GET_MEMORY_DATA_TRANSPORT_TIME
+            .observe((util::current_timestamp_ms() - req.timestamp as u128) as f64);
 
         let app = self.app_manager_ref.get_app(&app_id);
         if app.is_none() {

--- a/src/util.rs
+++ b/src/util.rs
@@ -58,6 +58,12 @@ pub fn get_crc(bytes: &Bytes) -> i64 {
     crc32.finalize() as i64
 }
 
+pub fn current_timestamp_ms() -> u128 {
+    let current_time = SystemTime::now();
+    let timestamp = current_time.duration_since(UNIX_EPOCH).unwrap().as_millis();
+    timestamp
+}
+
 pub fn current_timestamp_sec() -> u64 {
     let current_time = SystemTime::now();
     let timestamp = current_time.duration_since(UNIX_EPOCH).unwrap().as_secs();


### PR DESCRIPTION
use the prometheus ql `histogram_quantile(0.8, sum(rate(grpc_send_data_transport_time_bucket{job="uniffle-worker"}[2m])) by (le))` to get the p99