### PR TITLE
feat: make tokio-console as a default feature

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
 [build]
-rustflags = ["-A", "dead-code", "-D", "warnings"]
+rustflags = ["-A", "dead-code", "-D", "warnings", "--cfg", "tokio_unstable"]

--- a/README.md
+++ b/README.md
@@ -116,11 +116,11 @@ export CLASSPATH=$(${HADOOP_HOME}/bin/hadoop classpath --glob)
 ## Profiling
 
 ### Tokio console
-1. build with unstable tokio for uniffle-worker binary
+1. build with unstable tokio for uniffle-worker binary (this has been enabled by default)
     ```shell
-    RUSTFLAGS="--cfg tokio_unstable" cargo build
+    cargo build
     ```
-2. worker run with tokio-console. the log level of trace must be enabled
+2. worker run with tokio-console. the log level of `trace` must be enabled
     ```shell
     WORKER_IP={ip} RUST_LOG=trace WORKER_CONFIG_PATH=./config.toml ./uniffle-worker
     ```


### PR DESCRIPTION
If no this PR, the console-subscriber will panic when the ["--cfg", "tokio_unstable"] is not in rustflags